### PR TITLE
Bento-108 Improve Data-loader performance

### DIFF
--- a/common/data_loader.py
+++ b/common/data_loader.py
@@ -668,9 +668,10 @@ class DataLoader:
 
     def wipe_db(self, session):
         cleanup_db = 'MATCH (n) DETACH DELETE n'
-
-        result = session.run(cleanup_db)
-        self.log.info('{} nodes deleted!'.format(result.summary().counters.nodes_deleted))
-        self.log.info('{} relationships deleted!'.format(result.summary().counters.relationships_deleted))
+        result = session.run(cleanup_db).summary()
+        self.nodes_deleted = result.counters.nodes_deleted
+        self.relationships_deleted = result.counters.relationships_deleted
+        self.log.info('{} nodes deleted!'.format(self.nodes_deleted))
+        self.log.info('{} relationships deleted!'.format(self.relationships_deleted))
 
 


### PR DESCRIPTION
Cached cycle node query results to prevent repeat querying. 
Fixed bug where number of deleted relationships and nodes were not correctly read and stored.