### PR TITLE
Create indexes before loading

### DIFF
--- a/common/props.py
+++ b/common/props.py
@@ -18,6 +18,7 @@ class Props:
                 self.visit_date_in_nodes = props.get('visit_date_in_nodes', {})
                 self.domain = props.get('domain', 'Unknown.domain.nci.nih.gov')
                 self.rel_prop_delimiter = props.get('rel_prop_delimiter', '$')
+                self.indexes = props.get('indexes', [])
         else:
             msg = f'Can NOT open file: "{file_name}"'
             self.log.error(msg)


### PR DESCRIPTION
Bento462 - creates indexes for each of the entries in the "id_fields" section of the properties files if the index does not already exist