### PR TITLE
Bento616 Enabled Split Transactions

### DIFF
--- a/common/config.py
+++ b/common/config.py
@@ -37,6 +37,7 @@ class BentoConfig:
             self.loading_mode = None
             self.dataset = None
             self.no_parents = None
+            self.split_transactions = None
         else:
             if os.path.isfile(config_file):
                 with open(config_file) as c_file:
@@ -89,6 +90,7 @@ class BentoConfig:
                     self.loading_mode = config.get('loading_mode', 'UPSERT_MODE')
                     self.dataset = config.get('dataset')
                     self.no_parents = config.get('no_parents')
+                    self.split_transactions = config.get('split_transactions')
             else:
                 msg = f'Can NOT open configuration file "{config_file}"!'
                 self.log.error(msg)


### PR DESCRIPTION
-Added the --split-transactions argument
-Split Transactions mode requires backup
-Splits load operations into separate transactions for each file
-Split transactions splits wipe db operation into transactions of 10000 nodes each